### PR TITLE
Revert "include the most known equation: E=mc^2"

### DIFF
--- a/dist/data.json
+++ b/dist/data.json
@@ -2258,24 +2258,5 @@
 		"href":"https://scienceworld.wolfram.com/physics/LiftForce.html",
 		"contributed_by": ""
 	},
-	{
-	"name": "Mass–energy equivalence",
-	"latex": "$$E=mc^2$$",
-	"description": "In physics, mass–energy equivalence is the principle that anything having mass has an equivalent amount of energy and vice versa.",
-	"definition": {
-		"$$E$$": "energy",
-		"$$m$$": "mass",
-		"$$c$$": "speed of light"
-	},
-	"keywords": [
-		"Einstein",
-		" relativity"
-	],
-	"tags": [
-		"physics"
-	],
-	"href": "https://en.wikipedia.org/wiki/Mass%E2%80%93energy_equivalence",
-	"contributed_by": "marcowitz"
-	},
 
 ]


### PR DESCRIPTION
Reverts valispace/WhatsThatFormula#4
error: comma delimiter at the end 